### PR TITLE
kmerDecoder migration

### DIFF
--- a/include/kProcessor/algorithms.hpp
+++ b/include/kProcessor/algorithms.hpp
@@ -99,7 +99,7 @@ namespace kProcessor {
     kmerDecoder *initialize_kmerDecoder(std::string mode, std::map<std::string, int> parse_params);
 
 // Initialize kmerDecoder to hash and Ihash single kmer.
-    kmerDecoder *initialize_kmerDecoder(int kmer_size, int hash_mode = 1);
+    kmerDecoder *initialize_kmerDecoder(int kSize, hashingModes HM);
 
 /* set hashing mode for kmerDecoder object
  *
@@ -107,9 +107,9 @@ namespace kProcessor {
  * Mode 1: Integer Hashing | Reversible | Full Hashing
  * Mode 2: TwoBitsHashing | Not considered hashing, just store the two bits representation
 */
-    void kmerDecoder_setHashing(kmerDecoder *KD, int hash_mode, bool canonical = true);
+    void kmerDecoder_setHashing(kmerDecoder *KD, hashingModes hash_mode);
 
-    void kmerDecoder_setHashing(kDataFrame *KF, int hash_mode, bool canonical = true);
+    void kmerDecoder_setHashing(kDataFrame *KF, hashingModes hash_mode);
 
 /// Perform indexing to a sequences file with predefined kmers decoding mode, returns a colored kDataframe.
     void index(kmerDecoder *KD, string names_fileName, kDataFrame *frame);

--- a/include/kProcessor/kDataFrame.hpp
+++ b/include/kProcessor/kDataFrame.hpp
@@ -552,11 +552,11 @@ protected:
 public:
   kDataFrameMQF();
   explicit kDataFrameMQF(std::uint64_t kSize);
-  kDataFrameMQF(std::uint64_t kSize, int mode);
+  kDataFrameMQF(std::uint64_t kSize, hashingModes hash_mode);
   kDataFrameMQF(std::uint64_t ksize,uint8_t q,uint8_t fixedCounterSize,uint8_t tagSize
     ,double falsePositiveRate);
 
-  kDataFrameMQF(std::uint64_t ksize, uint8_t q, int mode);
+  kDataFrameMQF(std::uint64_t ksize, uint8_t q, hashingModes hash_mode);
 
   kDataFrameMQF(QF* mqf,std::uint64_t ksize,double falsePositiveRate);
   //count histogram is array where count of kmers repeated n times is found at index n. index 0 holds number of distinct kmers.
@@ -810,10 +810,10 @@ private:
     flat_hash_map<std::uint64_t, std::uint64_t> MAP;
 public:
     kDataFramePHMAP();
-
-    explicit kDataFramePHMAP(std::uint64_t ksize);
-    kDataFramePHMAP(std::uint64_t ksize, int mode);
-    kDataFramePHMAP(std::uint64_t kSize,vector<std::uint64_t> kmersHistogram);
+    kDataFramePHMAP(uint64_t ksize);
+    kDataFramePHMAP(readingModes RM, hashingModes hash_mode, map<string, int> params);
+    kDataFramePHMAP(uint64_t ksize, hashingModes hash_mode);
+    kDataFramePHMAP(uint64_t kSize,vector<uint64_t> kmersHistogram);
 
     kDataFrame *getTwin();
 

--- a/src/algorithms.cpp
+++ b/src/algorithms.cpp
@@ -302,14 +302,11 @@ namespace kProcessor {
             if (parse_params["mode"] == 2) mode = "skipmers";
             else if (parse_params["mode"] == 3) mode = "minimizers";
         }
-
-        parse_params["k_size"] = kframe->ksize();
-        parse_params["k"] = kframe->ksize();
-        kmerDecoder *KD = kmerDecoder::getInstance(filename, chunk_size, kframe->KD->slicing_mode, kframe->KD->hash_mode, parse_params);
+        kmerDecoder *KD = kmerDecoder::getInstance(filename, chunk_size, kframe->KD->slicing_mode, kframe->KD->hash_mode, {{"kSize", kframe->ksize()}});
 
         // Clone the hashing
 
-        kmerDecoder_setHashing(KD, kframe->KD->hash_mode);
+        // kmerDecoder_setHashing(KD, kframe->KD->hash_mode);
 
         // Processing
 

--- a/src/algorithms.cpp
+++ b/src/algorithms.cpp
@@ -24,165 +24,6 @@ using phmap::flat_hash_map;
 #define QBITS_LOCAL_QF 16
 
 namespace kProcessor {
-    // TO BE REMOVED TODO V2
-    /*
-    static inline void insertToLevels(uint64_t item, QF *local, QF *main, QF *diskMQF = NULL) {
-        if (!qf_insert(main, item, 1,
-                       true, false)) {
-            qf_insert(local, item, 1,
-                      false, false);
-            // check of the load factor of the local QF is more than 50%
-            if (qf_space(local) > 50) {
-
-                {
-                    if (main->metadata->noccupied_slots + local->metadata->noccupied_slots
-                        < main->metadata->maximum_occupied_slots) {
-                        qf_migrate(local, main);
-                    } else if (diskMQF != NULL) {
-                        SEQAN_OMP_PRAGMA(critical){
-                            qf_general_lock(main, true);
-                            qf_migrate(main, diskMQF);
-                            qf_reset(main);
-                            qf_general_unlock(main);
-                            qf_migrate(local, main);
-                        }
-                    } else {
-                        throw overflow_error("memory MQF doesn't have enough space to migrate");
-                    }
-
-                }
-                qf_reset(local);
-            }
-        } else {
-            if (qf_space(main) > 90) {
-                SEQAN_OMP_PRAGMA(critical)
-                {
-                    if (qf_space(main) > 90) {
-                        if (diskMQF != NULL) {
-                            qf_general_lock(main, true);
-                            qf_migrate(main, diskMQF);
-                            qf_reset(main);
-                            qf_general_unlock(main);
-                        } else {
-                            throw overflow_error("memory MQF doesn't have enough space");
-                        }
-                    }
-                }
-            }
-        }
-    }
-    */
-
-// TO BE REMOVED TODO V2
-/*
-    void loadIntoMQF(string sequenceFilename, unsigned int ksize, int noThreads, Hasher *hasher, QF *memoryMQF,
-                     QF *diskMQF) {
-        FastqReaderSqueker reader(sequenceFilename);
-        omp_set_num_threads(noThreads);
-        QF *localMQF;
-        bool moreWork = true;
-        uint64_t numReads = 0;
-        deque<pair<string, string> > reads;
-        string read, tag;
-#pragma omp parallel private(reads, localMQF, read, tag) shared(reader, moreWork, numReads)  firstprivate(ksize, noThreads, memoryMQF, diskMQF)
-        {
-            auto localHasher = hasher->clone();
-            localMQF = new QF();
-            reads = deque<pair<string, string> >(15000);
-            qf_init(localMQF, (1ULL << QBITS_LOCAL_QF), memoryMQF->metadata->key_bits,
-                    0, memoryMQF->metadata->fixed_counter_size, 0, true, "", 2038074761);
-            while (moreWork) {
-                SEQAN_OMP_PRAGMA(critical)
-                {
-                    reader.readNSeq(&reads, 15000);
-                    numReads += 15000;
-                    bool tmp = !reader.isEOF();
-                    moreWork = tmp;
-                }
-
-                for (unsigned int j = 0; j < reads.size(); j++) {
-                    read = reads[j].first;
-                    start_read:
-                    if (read.size() < ksize) {
-                        continue;
-                    }
-
-                    uint64_t first = 0;
-                    uint64_t first_rev = 0;
-                    uint64_t item = 0;
-
-                    for (unsigned int i = 0; i < ksize; i++) {
-                        //First kmer
-                        uint8_t curr = kmer::map_base(read[i]);
-                        if (curr > DNA_MAP::G) {
-                            // 'N' is encountered
-
-                            read = read.substr(i + 1, read.length());
-
-                            //continue;
-                            goto start_read;
-                        }
-                        first = first | curr;
-                        first = first << 2;
-                    }
-                    first = first >> 2;
-                    first_rev = kmer::reverse_complement(first, ksize);
-
-
-                    if (kmer::compare_kmers(first, first_rev))
-                        item = first;
-                    else
-                        item = first_rev;
-
-                    item = localHasher->hash(item) % memoryMQF->metadata->range;
-                    insertToLevels(item, localMQF, memoryMQF, diskMQF);
-
-                    uint64_t next = (first << 2) & BITMASK(2 * ksize);
-                    uint64_t next_rev = first_rev >> 2;
-
-                    for (uint32_t i = ksize; i < length(read); i++) {
-                        //next kmers
-                        //cout << "K: " << read.substr(i-K+1,K) << endl;
-                        uint8_t curr = kmer::map_base(read[i]);
-                        if (curr > DNA_MAP::G) {
-                            // 'N' is encountered
-                            //continue;
-                            //read = read.substr(i+1, length(read));
-                            read = read.substr(i + 1, read.length());
-                            //erase(read,0,i+1);
-
-                            goto start_read;
-                        }
-                        next |= curr;
-                        uint64_t tmp = kmer::reverse_complement_base(curr);
-                        tmp <<= (ksize * 2 - 2);
-                        next_rev = next_rev | tmp;
-                        if (kmer::compare_kmers(next, next_rev))
-                            item = next;
-                        else
-                            item = next_rev;
-
-
-                        item = localHasher->hash(item) % memoryMQF->metadata->range;
-                        insertToLevels(item, localMQF, memoryMQF, diskMQF);
-                        next = (next << 2) & BITMASK(2 * ksize);
-                        next_rev = next_rev >> 2;
-                    }
-                }
-
-            }
-            //    #pragma omp critical
-            {
-                qf_migrate(localMQF, memoryMQF);
-            }
-            qf_destroy(localMQF);
-        }
-        if (diskMQF != NULL) {
-            qf_migrate(memoryMQF, diskMQF);
-        }
-
-    }
-*/
 
     void dumpMQF(QF *MQF, int ksize, std::string outputFilename) {
         IntegerHasher Ihasher(BITMASK(2 * ksize));
@@ -465,11 +306,11 @@ namespace kProcessor {
 
         parse_params["k_size"] = kframe->ksize();
         parse_params["k"] = kframe->ksize();
-        kmerDecoder *KD = initialize_kmerDecoder(filename, chunk_size, mode, parse_params);
+        kmerDecoder *KD = kmerDecoder::getInstance(filename, chunk_size, kframe->KD->slicing_mode, kframe->KD->hash_mode, parse_params);
 
         // Clone the hashing
 
-        kmerDecoder_setHashing(KD, kframe->KD->hash_mode, kframe->KD->canonical);
+        kmerDecoder_setHashing(KD, kframe->KD->hash_mode);
 
         // Processing
 
@@ -521,7 +362,7 @@ namespace kProcessor {
 
         // Clone the hashing
 
-        kmerDecoder_setHashing(KD, frame->KD->hash_mode, frame->KD->canonical);
+        kmerDecoder_setHashing(KD, frame->KD->hash_mode);
 
         if (KD->get_kSize() != (int) frame->getkSize()) {
             std::cerr << "kmerDecoder kSize must be equal to kDataFrame kSize" << std::endl;
@@ -706,12 +547,12 @@ namespace kProcessor {
     }
 
 
-    void kmerDecoder_setHashing(kmerDecoder *KD, int hash_mode, bool canonical) {
-        KD->setHashingMode(hash_mode, canonical);
+    void kmerDecoder_setHashing(kmerDecoder * KD, hashingModes hash_mode){
+        KD->setHashingMode(hash_mode, KD->get_kSize());
     }
 
-    void kmerDecoder_setHashing(kDataFrame *KF, int hash_mode, bool canonical) {
-        KF->KD->setHashingMode(hash_mode, canonical);
+    void kmerDecoder_setHashing(kDataFrame * KF, hashingModes hash_mode){
+        KF->KD->setHashingMode(hash_mode, KF->ksize());
     }
 
 
@@ -810,11 +651,8 @@ namespace kProcessor {
         }
     }
 
-    kmerDecoder *initialize_kmerDecoder(int kSize, int hash_mode) {
-        // Mode 0: Murmar Hashing | Irreversible
-        // Mode 1: Integer Hashing | Reversible | Full Hashing
-        // Mode 2: TwoBitsHashing | Not considered hashing, just store the two bits representation
-        return new Kmers(kSize, hash_mode);
+    kmerDecoder* initialize_kmerDecoder(int kSize, hashingModes HM = integer_hasher){
+        return new Kmers(kSize, HM);
     }
 
     void index(kmerDecoder *KD, string names_fileName, kDataFrame *frame) {
@@ -1019,7 +857,7 @@ namespace kProcessor {
 
         // Clone the hashing
 
-        kmerDecoder_setHashing(KD, frame->KD->hash_mode, frame->KD->canonical);
+        kmerDecoder_setHashing(KD, frame->KD->hash_mode);
 
         // Processing
 

--- a/src/kDataFrames/kDataFrameBMQF.cpp
+++ b/src/kDataFrames/kDataFrameBMQF.cpp
@@ -35,7 +35,7 @@ kDataFrameBMQF::kDataFrameBMQF(uint64_t ksize,uint8_t q,uint8_t fixedCounterSize
         KD = (new Kmers(kSize));
     }
     else if(falsePositiveRate<1){
-        KD = (new Kmers(kSize,0));
+        KD = (new Kmers(kSize, mumur_hasher));
     }
     hashbits=2*kSize;
     range=(1ULL<<hashbits);
@@ -73,7 +73,7 @@ kDataFrameBMQF::kDataFrameBMQF(bufferedMQF* bufferedmqf,uint64_t ksize,double fa
         KD = (new Kmers(kSize));
     }
     else if(falsePositiveRate<1){
-        KD = (new Kmers(kSize,0));
+        KD = (new Kmers(kSize, mumur_hasher));
     }
     hashbits=this->bufferedmqf->memoryBuffer->metadata->key_bits;
     hashbits=2*kSize;

--- a/src/kDataFrames/kDataFrameMAP.cpp
+++ b/src/kDataFrames/kDataFrameMAP.cpp
@@ -76,7 +76,7 @@ kDataFrameMAPIterator::~kDataFrameMAPIterator() {
 kDataFrameMAP::kDataFrameMAP(uint64_t ksize) {
     this->class_name = "MAP"; // Temporary until resolving #17
     this->kSize = ksize;
-    KD = new Kmers(ksize, 2);
+    KD = new Kmers(ksize, TwoBits_hasher);
 //    hasher = new wrapperHasher<std::map<uint64_t, uint64_t>::hasher>(MAP.hash_function(), ksize);
 //    this->MAP = std::map<uint64_t, uint64_t>(1000);
     // this->hasher = (new IntegerHasher(ksize));
@@ -86,7 +86,7 @@ kDataFrameMAP::kDataFrameMAP(uint64_t ksize) {
 }
 kDataFrameMAP::kDataFrameMAP(uint64_t ksize,vector<uint64_t> kmersHistogram) {
     this->class_name = "MAP"; // Temporary until resolving #17
-    KD = new Kmers(ksize, 2);
+    KD = new Kmers(ksize, TwoBits_hasher);
     this->kSize = ksize;
     uint64_t countSum=0;
     for(auto h:kmersHistogram)
@@ -102,7 +102,7 @@ kDataFrameMAP::kDataFrameMAP(uint64_t ksize,vector<uint64_t> kmersHistogram) {
 kDataFrameMAP::kDataFrameMAP() {
     this->class_name = "MAP"; // Temporary until resolving #17
     this->kSize = 23;
-    KD = new Kmers(this->kSize, 2);
+    KD = new Kmers(this->kSize, TwoBits_hasher);
     endIterator=new kDataFrameIterator(
             (_kDataFrameIterator *) new kDataFrameMAPIterator(MAP.end(), this, kSize),
             (kDataFrame *) this);

--- a/src/kDataFrames/kDataFrameMQF.cpp
+++ b/src/kDataFrames/kDataFrameMQF.cpp
@@ -157,7 +157,7 @@ kDataFrameMQF::kDataFrameMQF() : kDataFrame() {
     endIterator=new  kDataFrameIterator(it,(kDataFrame*)this);
 }
 
-kDataFrameMQF::kDataFrameMQF(uint64_t ksize, uint8_t q, int mode) : kDataFrame(ksize) {
+kDataFrameMQF::kDataFrameMQF(uint64_t ksize, uint8_t q, hashingModes hash_mode) : kDataFrame(ksize) {
 
     this->class_name = "MQF"; // Temporary until resolving #17
 
@@ -165,7 +165,7 @@ kDataFrameMQF::kDataFrameMQF(uint64_t ksize, uint8_t q, int mode) : kDataFrame(k
     // Mode 1: Integer Hashing | Reversible | Full Hashing
     // Mode 2: TwoBitsHashing | Not considered hashing, just store the two bits representation
 
-    KD = new Kmers(ksize, mode);
+    KD = new Kmers(ksize, hash_mode);
 
 
 //    switch (mode) {
@@ -206,9 +206,9 @@ kDataFrameMQF::kDataFrameMQF(uint64_t ksize, uint8_t q, uint8_t fixedCounterSize
     qf_init(mqf, (1ULL << q), 2 * ksize, tagSize, fixedCounterSize, 32, true, "", 2038074761);
     this->falsePositiveRate = falsePositiveRate;
     if (falsePositiveRate == 0) {
-        KD = (new Kmers(kSize,1));
+        KD = (new Kmers(kSize, integer_hasher));
     } else if (falsePositiveRate < 1) {
-        KD = (new Kmers(kSize, 0));
+        KD = (new Kmers(kSize, mumur_hasher));
     }
     hashbits = 2 * kSize;
     range = (1ULL << hashbits);
@@ -218,11 +218,11 @@ kDataFrameMQF::kDataFrameMQF(uint64_t ksize, uint8_t q, uint8_t fixedCounterSize
     endIterator=new  kDataFrameIterator(it,(kDataFrame*)this);
 }
 
-kDataFrameMQF::kDataFrameMQF(uint64_t ksize, int mode) :
+kDataFrameMQF::kDataFrameMQF(uint64_t ksize, hashingModes hash_mode) :
     kDataFrame(ksize) {
     this->class_name = "MQF"; // Temporary until resolving #17
     this->falsePositiveRate = 0.0;
-    KD = new Kmers(ksize, mode);
+    KD = new Kmers(ksize, hash_mode);
     hashbits = 2 * kSize;
     range = (1ULL << hashbits);
     mqf = NULL;
@@ -235,7 +235,7 @@ kDataFrameMQF::kDataFrameMQF(uint64_t ksize) :
         kDataFrame(ksize) {
     this->class_name = "MQF"; // Temporary until resolving #17
     this->falsePositiveRate = 0.0;
-    KD = (new Kmers(kSize));
+    KD = (new Kmers(kSize, integer_hasher));
     hashbits = 2 * kSize;
     range = (1ULL << hashbits);
     mqf = NULL;
@@ -249,9 +249,9 @@ kDataFrameMQF::kDataFrameMQF(QF *mqf, uint64_t ksize, double falsePositiveRate) 
     this->mqf = mqf;
     this->falsePositiveRate = falsePositiveRate;
     if (falsePositiveRate == 0) {
-        KD = (new Kmers(kSize));
+        KD = (new Kmers(kSize, integer_hasher));
     } else if (falsePositiveRate < 1) {
-        KD = (new Kmers(kSize, 0));
+        KD = (new Kmers(kSize, mumur_hasher));
     }
     hashbits = this->mqf->metadata->key_bits;
     hashbits = 2 * kSize;

--- a/src/kDataFrames/kDataFramePHMAP.cpp
+++ b/src/kDataFrames/kDataFramePHMAP.cpp
@@ -15,7 +15,7 @@ kDataFramePHMAPIterator::kDataFramePHMAPIterator(flat_hash_map<uint64_t, uint64_
         : _kDataFrameIterator(kSize) {
     iterator = it;
     this->origin = origin;
-    this->KD = origin->getkmerDecoder();
+    this->KD = this->origin->KD;
 }
 
 kDataFramePHMAPIterator::kDataFramePHMAPIterator(const kDataFramePHMAPIterator &other) :
@@ -74,7 +74,7 @@ kDataFramePHMAPIterator::~kDataFramePHMAPIterator() {
 kDataFramePHMAP::kDataFramePHMAP(uint64_t ksize) {
     this->class_name = "PHMAP"; // Temporary until resolving #17
     this->kSize = ksize;
-    KD = new Kmers(kSize, 2);
+    KD = new Kmers(kSize, TwoBits_hasher);
 //    hasher = new wrapperHasher<flat_hash_map<uint64_t, uint64_t>::hasher>(MAP.hash_function(), ksize);
     this->MAP = flat_hash_map<uint64_t, uint64_t>(1000);
     endIterator= new kDataFrameIterator(
@@ -83,22 +83,29 @@ kDataFramePHMAP::kDataFramePHMAP(uint64_t ksize) {
     // this->hasher = (new IntegerHasher(ksize));
 }
 
-kDataFramePHMAP::kDataFramePHMAP(uint64_t ksize, int mode) {
+kDataFramePHMAP::kDataFramePHMAP(uint64_t ksize, hashingModes hash_mode) {
     this->class_name = "PHMAP"; // Temporary until resolving #17
     this->kSize = ksize;
-    KD = new Kmers(kSize, mode);
+    KD = new Kmers(kSize, hash_mode);
 //    hasher = new wrapperHasher<flat_hash_map<uint64_t, uint64_t>::hasher>(MAP.hash_function(), ksize);
     this->MAP = flat_hash_map<uint64_t, uint64_t>(1000);
     // this->hasher = (new IntegerHasher(ksize));
     endIterator= new kDataFrameIterator(
             (_kDataFrameIterator *) new kDataFramePHMAPIterator(MAP.end(), this, kSize),
             (kDataFrame *) this);
+}
+
+kDataFramePHMAP::kDataFramePHMAP(readingModes RM, hashingModes hash_mode, map<string, int> params) {
+    this->class_name = "PHMAP"; // Temporary until resolving #17
+    KD = kmerDecoder::getInstance(RM, hash_mode, params);
+    this->kSize = KD->get_kSize();
+    this->MAP = flat_hash_map<uint64_t, uint64_t>(1000);
 }
 
 kDataFramePHMAP::kDataFramePHMAP(uint64_t ksize,vector<uint64_t> kmersHistogram) {
     this->class_name = "PHMAP"; // Temporary until resolving #17
     this->kSize = ksize;
-    KD = new Kmers(kSize, 2);
+    KD = new Kmers(kSize, TwoBits_hasher);
 //    hasher = new wrapperHasher<flat_hash_map<uint64_t, uint64_t>::hasher>(MAP.hash_function(), ksize);
 
     uint64_t countSum=0;
@@ -117,7 +124,7 @@ kDataFramePHMAP::kDataFramePHMAP() {
     this->class_name = "PHMAP"; // Temporary until resolving #17
     this->kSize = 23;
     this->MAP = flat_hash_map<uint64_t, uint64_t>(1000);
-    KD = new Kmers(kSize, 2);
+    KD = new Kmers(kSize, TwoBits_hasher);
     // hasher=new wrapperHasher<flat_hash_map<uint64_t,uint64_t>::hasher >(MAP.hash_function(),kSize);
     // this->hasher = (new IntegerHasher(23));
     endIterator= new kDataFrameIterator(
@@ -237,8 +244,8 @@ kDataFrame *kDataFramePHMAP::load(string filePath) {
     file >> hashing_mode;
     file.close();
     filePath += ".phmap";
-    
-    kDataFramePHMAP *KMAP = new kDataFramePHMAP(kSize, hashing_mode);
+    hashingModes hash_mode = static_cast<hashingModes>(hashing_mode);
+    kDataFramePHMAP *KMAP = new kDataFramePHMAP(kSize, hash_mode);
     {
         phmap::BinaryInputArchive ar_in(filePath.c_str());
         KMAP->MAP.load(ar_in);
@@ -253,7 +260,7 @@ kDataFrame *kDataFramePHMAP::load(string filePath) {
 }
 
 kDataFrame *kDataFramePHMAP::getTwin() {
-    return ((kDataFrame *) new kDataFramePHMAP(kSize));
+    return ((kDataFrame *) new kDataFramePHMAP(kSize, this->KD->hash_mode));
 }
 
 void kDataFramePHMAP::reserve(uint64_t n) {

--- a/tests/kProcessorLibTests/testkDataFrame.cpp
+++ b/tests/kProcessorLibTests/testkDataFrame.cpp
@@ -29,6 +29,9 @@ string gen_random(const int len) {
     return s;
 }
 map< pair<uint64_t,uint64_t>, insertColorColumn*> insertColumns;
+
+
+
 INSTANTIATE_TEST_SUITE_P(testcolorsTable,
                          queryColumnTest,
                         ::testing::Combine(
@@ -834,18 +837,18 @@ TEST_P(algorithmsTest,parsingTest)
   int chunkSize=1000;
 
   kProcessor::countKmersFromFile(kframe, {{"mode", 1}}, fileName, 1000); // Mode 1 : kmers, KmerSize will be cloned from the kFrame
-  kmerDecoder *KMERS = kProcessor::initialize_kmerDecoder(fileName, 1000, "kmers", {{"k_size", kSize}});
+  kmerDecoder *KD_KMERS = kProcessor::initialize_kmerDecoder(fileName, 1000, "kmers", {{"k_size", kSize}});
 
-    while (!KMERS->end()) {
-        KMERS->next_chunk();
-        for (const auto &seq : *KMERS->getKmers()) {
+    while (!KD_KMERS->end()) {
+        KD_KMERS->next_chunk();
+        for (const auto &seq : *KD_KMERS->getKmers()) {
             for (const auto &kmer : seq.second) {
                 ASSERT_GE(kframe->getCount(kmer.str),1);
             }
         }
     }
 
-    delete KMERS;
+    delete KD_KMERS;
     delete kframe;
     
     
@@ -862,18 +865,18 @@ TEST_P(algorithmsTest,loadingKMCTest)
 
     kProcessor::loadFromKMC(kframe,db);
 
-    kmerDecoder *KMERS = kProcessor::initialize_kmerDecoder(fileName, 1000, "kmers", {{"k_size", kSize}});
+    kmerDecoder *KD_KMERS = kProcessor::initialize_kmerDecoder(fileName, 1000, "kmers", {{"k_size", kSize}});
 
-    while (!KMERS->end()) {
-        KMERS->next_chunk();
-        for (const auto &seq : *KMERS->getKmers()) {
+    while (!KD_KMERS->end()) {
+        KD_KMERS->next_chunk();
+        for (const auto &seq : *KD_KMERS->getKmers()) {
             for (const auto &kmer : seq.second) {
                 ASSERT_GE(kframe->getCount(kmer.str),1);
             }
         }
     }
 
-    delete KMERS;
+    delete KD_KMERS;
     delete kframe;
 
 
@@ -1038,14 +1041,14 @@ TEST_P(indexingTest,index)
 {
   string filename=GetParam();
   int chunkSize = 1000;
-
-  kDataFrame *KF = new kDataFrameMQF(25, 25, 1);
-  kmerDecoder *KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
-  kProcessor::index(KMERS, filename+".names", KF);
+  int q = 25;
+  kDataFrame *KF = new kDataFrameMQF(25, q, integer_hasher);
+  kmerDecoder *KD_KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
+  kProcessor::index(KD_KMERS, filename+".names", KF);
 
   uint64_t kSize=KF->getkSize();
 
-  delete KMERS;
+  delete KD_KMERS;
   string names_fileName=filename+".names";
   ifstream namesFile(names_fileName.c_str());
   string seqName, groupName,line;
@@ -1062,11 +1065,11 @@ TEST_P(indexingTest,index)
     }
     namesFile.close();
 
-    KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
+    KD_KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
 
-    while (!KMERS->end()) {
-            KMERS->next_chunk();
-            for (const auto &seq : *KMERS->getKmers()) {
+    while (!KD_KMERS->end()) {
+            KD_KMERS->next_chunk();
+            for (const auto &seq : *KD_KMERS->getKmers()) {
                 string readName = seq.first;
                 string groupName=namesMap[readName];
                 for (const auto &kmer : seq.second) {
@@ -1078,7 +1081,7 @@ TEST_P(indexingTest,index)
                 }
             }
     }
-    delete KF,KMERS;
+    delete KF,KD_KMERS;
 
 }
 
@@ -1087,15 +1090,16 @@ TEST_P(indexingTest,indexPriorityQSaveAndLoad)
     string filename=GetParam();
     int chunkSize = 1000;
 
-    kDataFrame *KF = new kDataFrameMQF(25, 25, 1);
-    kmerDecoder *KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
+    int q = 25;
+    kDataFrame *KF = new kDataFrameMQF(25, q, integer_hasher);
+    kmerDecoder *KD_KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
 
 
     vector<kDataFrame*> inputFrames;
-    while (!KMERS->end()) {
-        KMERS->next_chunk();
-        for (const auto &seq : *KMERS->getKmers()) {
-            kDataFrame* curr=new kDataFrameMAP(KMERS->get_kSize());
+    while (!KD_KMERS->end()) {
+        KD_KMERS->next_chunk();
+        for (const auto &seq : *KD_KMERS->getKmers()) {
+            kDataFrame* curr=new kDataFrameMAP(KD_KMERS->get_kSize());
             for (const auto &kmer : seq.second) {
                 curr->insert(kmer.hash);
             }
@@ -1123,7 +1127,7 @@ TEST_P(indexingTest,indexPriorityQSaveAndLoad)
     }
 
     delete kframeLoaded;
-    delete KMERS;
+    delete KD_KMERS;
 
 }
 
@@ -1131,16 +1135,16 @@ TEST_P(indexingTest,indexPriorityQ)
 {
     string filename=GetParam();
     int chunkSize = 1000;
-
-    kDataFrame *KF = new kDataFrameMQF(25, 25, 1);
-    kmerDecoder *KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
+    int q = 25;
+    kDataFrame *KF = new kDataFrameMQF(25, q, integer_hasher);
+    kmerDecoder *KD_KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
 
 
     vector<kDataFrame*> inputFrames;
-    while (!KMERS->end()) {
-        KMERS->next_chunk();
-        for (const auto &seq : *KMERS->getKmers()) {
-            kDataFrame* curr=new kDataFrameMAP(KMERS->get_kSize());
+    while (!KD_KMERS->end()) {
+        KD_KMERS->next_chunk();
+        for (const auto &seq : *KD_KMERS->getKmers()) {
+            kDataFrame* curr=new kDataFrameMAP(KD_KMERS->get_kSize());
             for (const auto &kmer : seq.second) {
                 curr->insert(kmer.hash);
             }
@@ -1167,7 +1171,7 @@ TEST_P(indexingTest,indexPriorityQ)
     }
 
     delete KF;
-    delete KMERS;
+    delete KD_KMERS;
 
 }
 
@@ -1176,15 +1180,16 @@ TEST_P(indexingTest,mergeIndexes)
     string filename=GetParam();
     int chunkSize = 1000;
 
-    kDataFrame *KF = new kDataFrameMQF(25, 25, 1);
-    kmerDecoder *KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
+    int q = 25;
+    kDataFrame *KF = new kDataFrameMQF(25, q, integer_hasher);
+    kmerDecoder *KD_KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
 
 
     vector<kDataFrame*> inputFrames;
-    while (!KMERS->end()) {
-        KMERS->next_chunk();
-        for (const auto &seq : *KMERS->getKmers()) {
-            kDataFrame* curr=new kDataFrameMAP(KMERS->get_kSize());
+    while (!KD_KMERS->end()) {
+        KD_KMERS->next_chunk();
+        for (const auto &seq : *KD_KMERS->getKmers()) {
+            kDataFrame* curr=new kDataFrameMAP(KD_KMERS->get_kSize());
             for (const auto &kmer : seq.second) {
                 curr->insert(kmer.hash);
             }
@@ -1207,7 +1212,8 @@ TEST_P(indexingTest,mergeIndexes)
             for(int j=(i+1)*sizeOfIndexes; j<inputFrames.size();j++)
                 input.push_back(inputFrames[j]);
         }
-        kDataFrame *KF2 = new kDataFrameMQF(25,25,2);
+        int q = 25;
+        kDataFrame *KF2 = new kDataFrameMQF(25, q, TwoBits_hasher);
         kProcessor::indexPriorityQueue(input,"", KF2);
         indexes[i]=KF2;
     }
@@ -1233,7 +1239,7 @@ TEST_P(indexingTest,mergeIndexes)
     }
 
     delete KF;
-    delete KMERS;
+    delete KD_KMERS;
 
 }
 
@@ -1242,9 +1248,10 @@ TEST_P(indexingTest,saveAndLoad)
     string filename=GetParam();
     int chunkSize = 1000;
 
-    kDataFrame *KF = new kDataFrameMQF(25, 25, 1);
-    kmerDecoder *KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
-    kProcessor::index(KMERS, filename+".names", KF);
+    int q = 25;
+    kDataFrame *KF = new kDataFrameMQF(25, q, integer_hasher);
+    kmerDecoder *KD_KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
+    kProcessor::index(KD_KMERS, filename+".names", KF);
     string fileName="tmp.kdataframe."+gen_random(4);
     KF->save(fileName);
     delete KF;
@@ -1253,7 +1260,7 @@ TEST_P(indexingTest,saveAndLoad)
 
     uint64_t kSize=kframeLoaded->getkSize();
     //vector<uint32_t> colors;
-    delete KMERS;
+    delete KD_KMERS;
     string names_fileName=filename+".names";
     ifstream namesFile(names_fileName.c_str());
     string seqName, groupName,line;
@@ -1270,11 +1277,11 @@ TEST_P(indexingTest,saveAndLoad)
     }
     namesFile.close();
 
-    KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
+    KD_KMERS = kProcessor::initialize_kmerDecoder(filename, chunkSize, "kmers", {{"k_size", 25}});
 
-    while (!KMERS->end()) {
-        KMERS->next_chunk();
-        for (const auto &seq : *KMERS->getKmers()) {
+    while (!KD_KMERS->end()) {
+        KD_KMERS->next_chunk();
+        for (const auto &seq : *KD_KMERS->getKmers()) {
             string readName = seq.first;
             string groupName=namesMap[readName];
             for (const auto &kmer : seq.second) {
@@ -1286,7 +1293,7 @@ TEST_P(indexingTest,saveAndLoad)
             }
         }
     }
-    delete kframeLoaded,KMERS;
+    delete kframeLoaded,KD_KMERS;
 
 }
 

--- a/tests/kProcessorLibTests/testkDataFrame.cpp
+++ b/tests/kProcessorLibTests/testkDataFrame.cpp
@@ -832,7 +832,7 @@ TEST_P(algorithmsTest,parsingTest)
   int chunkSize=1000;
 
   kProcessor::countKmersFromFile(kframe, {{"mode", 1}}, fileName, 1000); // Mode 1 : kmers, KmerSize will be cloned from the kFrame
-  kmerDecoder *KD_KMERS = kProcessor::initialize_kmerDecoder(fileName, 1000, "kmers", {{"k_size", kSize}});
+  kmerDecoder *KD_KMERS = kmerDecoder::getInstance(fileName, chunkSize, KMERS, kframe->KD->hash_mode, {{"kSize", kSize}});
 
     while (!KD_KMERS->end()) {
         KD_KMERS->next_chunk();


### PR DESCRIPTION
This PR updates the kmerDecoder submodule with some modifications on kProcessor for compatibility.

@shokrof  please review and check if the tests are running as expected. I now have only 5 failing tests in this branch.

```
[  PASSED  ] 138 tests.
[  FAILED  ] 5 tests, listed below:
[  FAILED  ] testFrames/kDataFrameTest.saveAndLoadChangeDefaultColumn/2, where GetParam() = ("MAP", 21)
[  FAILED  ] testFrames/kDataFrameTest.saveAndLoadChangeDefaultColumn/4, where GetParam() = ("PHMAP", 21)
[  FAILED  ] testFrames/kDataFrameTest.saveAndIterateOverAllKmers/4, where GetParam() = ("PHMAP", 21)
[  FAILED  ] testFrames/kDataFrameTest.saveAndIterateOverAllKmers/5, where GetParam() = ("PHMAP", 31)
[  FAILED  ] testFrames/kDataFrameTest.transformPlus10/0, where GetParam() = ("MQF", 21)
```

This is a checkpoint. I will continue working on this migration one step at a time to make sure nothing will fail.